### PR TITLE
zstream trigger: do not stop process after the first trigger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,3 +51,11 @@ repos:
     rev: v8.18.2
     hooks:
       - id: gitleaks
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.9.0
+    hooks:
+      - id: mypy
+        exclude: ^(tests/)
+        include: ci_jobs_trigger/libs/openshift_ci/ztream_trigger
+        additional_dependencies: [types-all]

--- a/ci_jobs_trigger/libs/addons_webhook_trigger/addons_webhook_trigger.py
+++ b/ci_jobs_trigger/libs/addons_webhook_trigger/addons_webhook_trigger.py
@@ -34,7 +34,7 @@ def get_merge_request(repository_data, object_attributes, project, logger):
     return merge_request
 
 
-def process_hook(data, logger, config_dict=None):
+def process_hook(data, logger):
     def _trigger_jobs(
         _addon,
         _ocm_env,
@@ -95,9 +95,7 @@ def process_hook(data, logger, config_dict=None):
 
     object_attributes = data["object_attributes"]
     if object_attributes.get("action") == "merge":
-        config_data = get_config(
-            config_dict=config_dict, os_environ=ADDONS_WEBHOOK_JOBS_TRIGGER_CONFIG_STR, logger=logger
-        )
+        config_data = get_config(os_environ=ADDONS_WEBHOOK_JOBS_TRIGGER_CONFIG_STR, logger=logger)
         repository_name = data["repository"]["name"]
         repository_data = repo_data_from_config(repository_name=repository_name, config_data=config_data)
         project = data["project"]["id"]

--- a/ci_jobs_trigger/libs/openshift_ci/ztream_trigger/zstream_trigger.py
+++ b/ci_jobs_trigger/libs/openshift_ci/ztream_trigger/zstream_trigger.py
@@ -131,9 +131,9 @@ def process_and_trigger_jobs(logger, version=None, config_dict=None):
                     processed_versions_file_path=_processed_versions_file_path,
                     logger=logger,
                 )
-                return True
+                continue
 
-        return False
+        return True
 
 
 def monitor_and_trigger(logger):

--- a/ci_jobs_trigger/libs/openshift_ci/ztream_trigger/zstream_trigger.py
+++ b/ci_jobs_trigger/libs/openshift_ci/ztream_trigger/zstream_trigger.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
 import json
+import logging
 import time
+from typing import Dict, List
 
 from ocp_utilities.cluster_versions import get_accepted_cluster_versions
 from semver import Version
@@ -9,11 +12,11 @@ from ci_jobs_trigger.utils.constant import DAYS_TO_SECONDS
 from ci_jobs_trigger.utils.general import get_config, send_slack_message
 from ci_jobs_trigger.libs.openshift_ci.utils.general import openshift_ci_trigger_job
 
-OPENSHIFT_CI_ZSTREAM_TRIGGER_CONFIG_OS_ENV_STR = "OPENSHIFT_CI_ZSTREAM_TRIGGER_CONFIG"
-LOG_PREFIX = "Zstream trigger:"
+OPENSHIFT_CI_ZSTREAM_TRIGGER_CONFIG_OS_ENV_STR: str = "OPENSHIFT_CI_ZSTREAM_TRIGGER_CONFIG"
+LOG_PREFIX: str = "Zstream trigger:"
 
 
-def processed_versions_file(processed_versions_file_path, logger):
+def processed_versions_file(processed_versions_file_path: str, logger: logging.Logger) -> Dict:
     try:
         with open(processed_versions_file_path) as fd:
             return json.load(fd)
@@ -24,7 +27,9 @@ def processed_versions_file(processed_versions_file_path, logger):
         return {}
 
 
-def update_processed_version(base_version, version, processed_versions_file_path, logger):
+def update_processed_version(
+    base_version: str, version: str, processed_versions_file_path: str, logger: logging.Logger
+) -> None:
     processed_versions_file_content = processed_versions_file(
         processed_versions_file_path=processed_versions_file_path, logger=logger
     )
@@ -35,7 +40,9 @@ def update_processed_version(base_version, version, processed_versions_file_path
         json.dump(processed_versions_file_content, fd)
 
 
-def already_processed_version(base_version, new_version, processed_versions_file_path, logger):
+def already_processed_version(
+    base_version: str, new_version: str, processed_versions_file_path: str, logger: logging.Logger
+) -> bool:
     if all_versions := processed_versions_file(
         processed_versions_file_path=processed_versions_file_path, logger=logger
     ).get(base_version):
@@ -43,39 +50,53 @@ def already_processed_version(base_version, new_version, processed_versions_file
     return False
 
 
-def trigger_jobs(config, jobs, logger):
-    failed_triggers_jobs = []
-    successful_triggers_jobs = []
-    for job in jobs:
-        res = openshift_ci_trigger_job(job_name=job, trigger_token=config["trigger_token"])
-
-        if res.ok:
-            successful_triggers_jobs.append(job)
-        else:
-            failed_triggers_jobs.append(job)
-
-    if successful_triggers_jobs:
-        success_msg = f"Triggered {len(successful_triggers_jobs)} jobs: {successful_triggers_jobs}"
-        logger.info(f"{LOG_PREFIX} {success_msg}")
+def trigger_jobs(config: Dict, jobs: List, logger: logging.Logger) -> bool:
+    failed_triggers_jobs: List = []
+    successful_triggers_jobs: List = []
+    if not jobs:
+        no_jobs_mgs: str = f"{LOG_PREFIX} No jobs to trigger"
+        logger.info(no_jobs_mgs)
         send_slack_message(
-            message=success_msg,
-            webhook_url=config.get("slack_webhook_url"),
-            logger=logger,
-        )
-        return True
-
-    if failed_triggers_jobs:
-        err_msg = f"Failed to trigger {len(failed_triggers_jobs)} jobs: {failed_triggers_jobs}"
-        logger.info(f"{LOG_PREFIX} {err_msg}")
-        send_slack_message(
-            message=err_msg,
+            message=no_jobs_mgs,
             webhook_url=config.get("slack_errors_webhook_url"),
             logger=logger,
         )
         return False
 
+    else:
+        for job in jobs:
+            res = openshift_ci_trigger_job(job_name=job, trigger_token=config["trigger_token"])
 
-def process_and_trigger_jobs(logger, version=None, config_dict=None):
+            if res.ok:
+                successful_triggers_jobs.append(job)
+            else:
+                failed_triggers_jobs.append(job)
+
+        if successful_triggers_jobs:
+            success_msg: str = f"Triggered {len(successful_triggers_jobs)} jobs: {successful_triggers_jobs}"
+            logger.info(f"{LOG_PREFIX} {success_msg}")
+            send_slack_message(
+                message=success_msg,
+                webhook_url=config.get("slack_webhook_url"),
+                logger=logger,
+            )
+            return True
+
+        if failed_triggers_jobs:
+            err_msg: str = f"Failed to trigger {len(failed_triggers_jobs)} jobs: {failed_triggers_jobs}"
+            logger.info(f"{LOG_PREFIX} {err_msg}")
+            send_slack_message(
+                message=err_msg,
+                webhook_url=config.get("slack_errors_webhook_url"),
+                logger=logger,
+            )
+            return False
+
+
+def process_and_trigger_jobs(
+    logger: logging.Logger, version: str | None = None, config_dict: Dict | None = None
+) -> bool:
+    trigger_res: Dict = {}
     config = get_config(
         os_environ=OPENSHIFT_CI_ZSTREAM_TRIGGER_CONFIG_OS_ENV_STR,
         logger=logger,
@@ -83,12 +104,11 @@ def process_and_trigger_jobs(logger, version=None, config_dict=None):
     )
     if not config:
         logger.error(f"{LOG_PREFIX} Could not get config.")
-        return False
+        return trigger_res
 
-    stable_versions = get_accepted_cluster_versions()["stable"]
-    if (versions_from_config := config.get("versions")) is None:
+    if not (versions_from_config := config.get("versions")):
         logger.error(f"{LOG_PREFIX} No versions found in config.yaml")
-        return False
+        return trigger_res
 
     if version:
         version_from_config = versions_from_config.get(version)
@@ -110,10 +130,11 @@ def process_and_trigger_jobs(logger, version=None, config_dict=None):
                         webhook_url=slack_error_url,
                         logger=logger,
                     )
+                trigger_res[version] = "No jobs found"
                 continue
 
-            version_str = str(version)
-            _latest_version = stable_versions[version_str][0]
+            version_str: str = str(version)
+            _latest_version = get_accepted_cluster_versions()["stable"][version_str][0]
             if already_processed_version(
                 base_version=version,
                 new_version=_latest_version,
@@ -121,6 +142,7 @@ def process_and_trigger_jobs(logger, version=None, config_dict=None):
                 logger=logger,
             ):
                 logger.info(f"{LOG_PREFIX} Version {version_str} already processed, skipping")
+                trigger_res[version] = "Already processed"
                 continue
 
             logger.info(f"{LOG_PREFIX} New Z-stream version {_latest_version} found, triggering jobs: {jobs}")
@@ -131,12 +153,13 @@ def process_and_trigger_jobs(logger, version=None, config_dict=None):
                     processed_versions_file_path=_processed_versions_file_path,
                     logger=logger,
                 )
+                trigger_res[version] = "Triggered"
                 continue
 
-        return True
+        return trigger_res
 
 
-def monitor_and_trigger(logger):
+def monitor_and_trigger(logger: logging.Logger) -> None:
     while True:
         try:
             process_and_trigger_jobs(logger=logger)

--- a/ci_jobs_trigger/libs/operators_iib_trigger/iib_trigger.py
+++ b/ci_jobs_trigger/libs/operators_iib_trigger/iib_trigger.py
@@ -231,7 +231,7 @@ def verify_s3_or_local_file(
 
 def fetch_update_iib_and_trigger_jobs(logger, tmp_dir, config_dict=None):
     logger.info(f"{LOG_PREFIX} Check for new operators IIB")
-    config_data = get_config(os_environ="CI_IIB_JOBS_TRIGGER_CONFIG", logger=logger, config_dict=config_dict)
+    config_data = get_config(os_environ="CI_IIB_JOBS_TRIGGER_CONFIG", logger=logger)
 
     s3_bucket_operators_latest_iib_path = config_data.get("s3_bucket_operators_latest_iib_path")
     user_local_operators_latest_iib_filepath = config_data.get("local_operators_latest_iib_filepath")

--- a/ci_jobs_trigger/tests/addons_webhook_trigger/test_addons_webhook_trigger.py
+++ b/ci_jobs_trigger/tests/addons_webhook_trigger/test_addons_webhook_trigger.py
@@ -78,9 +78,15 @@ def config_dict(tmp_path_factory):
     }
 
 
-def test_process_hook(mocker, functions_mocker, webhook_data, config_dict):
+@pytest.fixture
+def get_config_mocker(mocker):
+    return mocker.patch("ci_jobs_trigger.libs.addons_webhook_trigger.addons_webhook_trigger.get_config")
+
+
+def test_process_hook(mocker, functions_mocker, webhook_data, config_dict, get_config_mocker):
     mocker.patch.object(Gitlab, "auth", return_value=True)
     mocker.patch.object(ProjectManager, "get", return_value=MockGitlabProjectManager())
     mocker.patch.object(ProjectMergeRequestManager, "get", return_value=MockProjectMergeRequestManager())
+    get_config_mocker.return_value = config_dict
 
-    process_hook(data=webhook_data, logger=LOGGER, config_dict=config_dict)
+    process_hook(data=webhook_data, logger=LOGGER)

--- a/ci_jobs_trigger/tests/zstream_trigger/test_zstream_trigger.py
+++ b/ci_jobs_trigger/tests/zstream_trigger/test_zstream_trigger.py
@@ -76,7 +76,7 @@ def test_process_and_trigger_jobs_config_with_no_versions(config_dict_no_version
 
 
 def test_process_and_trigger_jobs_config_with_empty_version(config_dict_empty_version):
-    assert not process_and_trigger_jobs(config_dict=config_dict_empty_version, logger=LOGGER)
+    assert process_and_trigger_jobs(config_dict=config_dict_empty_version, logger=LOGGER) == {"4.15": "No jobs found"}
 
 
 def test_process_and_trigger_jobs(config_dict, job_trigger_and_get_versions_mocker):
@@ -89,7 +89,7 @@ def test_process_and_trigger_jobs_already_triggered(mocker, config_dict, job_tri
         return_value={"4.13": ["4.13.34", "4.13.33"]},
     )
 
-    assert not process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER)
+    assert process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER) == {"4.13": "Already processed"}
 
 
 def test_process_and_trigger_jobs_new_version(mocker, config_dict, job_trigger_and_get_versions_mocker):
@@ -103,3 +103,21 @@ def test_process_and_trigger_jobs_new_version(mocker, config_dict, job_trigger_a
 
 def test_process_and_trigger_jobs_set_version(config_dict, job_trigger_and_get_versions_mocker):
     assert process_and_trigger_jobs(version="4.13", config_dict=config_dict, logger=LOGGER)
+
+
+def test_process_and_trigger_jobs_pass_version(mocker, config_dict, job_trigger_and_get_versions_mocker):
+    mocker.patch(
+        f"{LIBS_ZSTREAM_TRIGGER_PATH}.processed_versions_file",
+        return_value={"4.13": ["4.13.33", "4.13.32"]},
+    )
+
+    assert process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER, version="4.13")
+
+
+def test_process_and_trigger_jobs_pass_version_not_in_config(mocker, config_dict, job_trigger_and_get_versions_mocker):
+    mocker.patch(
+        f"{LIBS_ZSTREAM_TRIGGER_PATH}.processed_versions_file",
+        return_value={"4.13": ["4.13.33", "4.13.32"]},
+    )
+    with pytest.raises(ValueError):
+        process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER, version="4.14")

--- a/ci_jobs_trigger/tests/zstream_trigger/test_zstream_trigger.py
+++ b/ci_jobs_trigger/tests/zstream_trigger/test_zstream_trigger.py
@@ -44,24 +44,29 @@ def base_config_dict(tmp_path_factory):
     }
 
 
+@pytest.fixture
+def get_config_mocker(mocker):
+    return mocker.patch(f"{LIBS_ZSTREAM_TRIGGER_PATH}.get_config")
+
+
 @pytest.fixture()
-def config_dict(base_config_dict):
+def config_dict(get_config_mocker, base_config_dict):
     base_config_dict["versions"] = {
         "4.13": ["<openshift-ci-test-name-4.13>"],
     }
-    return base_config_dict
+    get_config_mocker.return_value = base_config_dict
 
 
 @pytest.fixture()
-def config_dict_no_versions(base_config_dict):
+def config_dict_no_versions(get_config_mocker, base_config_dict):
     base_config_dict["versions"] = {}
-    return base_config_dict
+    get_config_mocker.return_value = base_config_dict
 
 
 @pytest.fixture()
-def config_dict_empty_version(base_config_dict):
+def config_dict_empty_version(get_config_mocker, base_config_dict):
     base_config_dict["versions"] = {"4.15": None}
-    return base_config_dict
+    get_config_mocker.return_value = base_config_dict
 
 
 def test_process_and_trigger_jobs_no_config():
@@ -72,15 +77,15 @@ def test_process_and_trigger_jobs_no_config():
 
 
 def test_process_and_trigger_jobs_config_with_no_versions(config_dict_no_versions):
-    assert not process_and_trigger_jobs(config_dict=config_dict_no_versions, logger=LOGGER)
+    assert not process_and_trigger_jobs(logger=LOGGER)
 
 
 def test_process_and_trigger_jobs_config_with_empty_version(config_dict_empty_version):
-    assert process_and_trigger_jobs(config_dict=config_dict_empty_version, logger=LOGGER) == {"4.15": "No jobs found"}
+    assert process_and_trigger_jobs(logger=LOGGER) == {"4.15": "No jobs found"}
 
 
 def test_process_and_trigger_jobs(config_dict, job_trigger_and_get_versions_mocker):
-    assert process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER)
+    assert process_and_trigger_jobs(logger=LOGGER)
 
 
 def test_process_and_trigger_jobs_already_triggered(mocker, config_dict, job_trigger_and_get_versions_mocker):
@@ -89,7 +94,7 @@ def test_process_and_trigger_jobs_already_triggered(mocker, config_dict, job_tri
         return_value={"4.13": ["4.13.34", "4.13.33"]},
     )
 
-    assert process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER) == {"4.13": "Already processed"}
+    assert process_and_trigger_jobs(logger=LOGGER) == {"4.13": "Already processed"}
 
 
 def test_process_and_trigger_jobs_new_version(mocker, config_dict, job_trigger_and_get_versions_mocker):
@@ -98,11 +103,11 @@ def test_process_and_trigger_jobs_new_version(mocker, config_dict, job_trigger_a
         return_value={"4.13": ["4.13.33", "4.13.32"]},
     )
 
-    assert process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER)
+    assert process_and_trigger_jobs(logger=LOGGER)
 
 
 def test_process_and_trigger_jobs_set_version(config_dict, job_trigger_and_get_versions_mocker):
-    assert process_and_trigger_jobs(version="4.13", config_dict=config_dict, logger=LOGGER)
+    assert process_and_trigger_jobs(version="4.13", logger=LOGGER)
 
 
 def test_process_and_trigger_jobs_pass_version(mocker, config_dict, job_trigger_and_get_versions_mocker):
@@ -111,7 +116,7 @@ def test_process_and_trigger_jobs_pass_version(mocker, config_dict, job_trigger_
         return_value={"4.13": ["4.13.33", "4.13.32"]},
     )
 
-    assert process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER, version="4.13")
+    assert process_and_trigger_jobs(logger=LOGGER, version="4.13")
 
 
 def test_process_and_trigger_jobs_pass_version_not_in_config(mocker, config_dict, job_trigger_and_get_versions_mocker):
@@ -120,4 +125,4 @@ def test_process_and_trigger_jobs_pass_version_not_in_config(mocker, config_dict
         return_value={"4.13": ["4.13.33", "4.13.32"]},
     )
     with pytest.raises(ValueError):
-        process_and_trigger_jobs(config_dict=config_dict, logger=LOGGER, version="4.14")
+        process_and_trigger_jobs(logger=LOGGER, version="4.14")

--- a/ci_jobs_trigger/utils/general.py
+++ b/ci_jobs_trigger/utils/general.py
@@ -23,10 +23,7 @@ class OpenshiftCiReTriggerError(Exception):
         return f"{self.log_prefix} Openshift CI job re-trigger failed: {self.msg}"
 
 
-def get_config(os_environ, logger, config_dict=None):
-    if config_dict:
-        return config_dict
-
+def get_config(os_environ, logger):
     try:
         return parse_config(path=os.environ.get(os_environ), default_value="")
     except Exception as ex:


### PR DESCRIPTION
When `process_and_trigger_jobs` called without `version`, continue to process all other versions.

Fix https://github.com/RedHatQE/ci-jobs-trigger/issues/95