### PR TITLE
z-stream: pass version with channel to processed_versions_file

### DIFF
--- a/ci_jobs_trigger/libs/openshift_ci/ztream_trigger/zstream_trigger.py
+++ b/ci_jobs_trigger/libs/openshift_ci/ztream_trigger/zstream_trigger.py
@@ -162,7 +162,7 @@ def process_and_trigger_jobs(logger: logging.Logger, version: str | None = None)
             )
             if trigger_jobs(config=config, jobs=_jobs, logger=logger):
                 update_processed_version(
-                    base_version=_wanted_version,
+                    base_version=_version,
                     version=str(_latest_version),
                     processed_versions_file_path=_processed_versions_file_path,
                     logger=logger,


### PR DESCRIPTION
Job is triggering every iteration when version in OPENSHIFT_CI_ZSTREAM_TRIGGER_CONFIG is `4.16-rc`, even if there is no new version

Expected behaviour should be `Version 4.16:rc already processed, skipping`

Update base_version in processed_version_file to save version with channel to skip already triggering for previous version.