### PR TITLE
Update Dockerfile to install rosa cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,14 @@ EXPOSE 5000
 
 ENV PRE_COMMIT_HOME=/tmp
 ENV GOCACHE=/tmp/.cache/go-build
+
+# Install the Rosa CLI
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz --output /tmp/rosa-linux.tar.gz \
+    && tar xvf /tmp/rosa-linux.tar.gz --no-same-owner \
+    && mv rosa /usr/bin/rosa \
+    && chmod +x /usr/bin/rosa \
+    && rosa version
+
 COPY pyproject.toml poetry.lock README.md /ci-jobs-trigger/
 COPY ci_jobs_trigger/ /ci-jobs-trigger/ci_jobs_trigger/
 WORKDIR /ci-jobs-trigger


### PR DESCRIPTION
To fix `Zstream trigger: Error: [Errno 2] No such file or directory: 'rosa'`