### PR TITLE
Add ENV OCM_CONFIG in Dockerfile to fix permission issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ COPY ci_jobs_trigger/ /ci-jobs-trigger/ci_jobs_trigger/
 WORKDIR /ci-jobs-trigger
 
 # Set OCM_CONFIG to save ocm credentials for login
-RUN mkdir -p config/ocm
+RUN mkdir -p config/ocm \
+    && chmod 755 /ci-jobs-trigger/config/ocm
 ENV OCM_CONFIG=/ci-jobs-trigger/config/ocm/ocm.json
 
 RUN python3 -m pip install pip --upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/ro
 COPY pyproject.toml poetry.lock README.md /ci-jobs-trigger/
 COPY ci_jobs_trigger/ /ci-jobs-trigger/ci_jobs_trigger/
 WORKDIR /ci-jobs-trigger
+
+# Set OCM_CONFIG to save ocm credentials for login
+RUN mkdir -p config/ocm
+ENV OCM_CONFIG=/ci-jobs-trigger/config/ocm/ocm.json
+
 RUN python3 -m pip install pip --upgrade \
     && python3 -m pip install poetry pre-commit \
     && poetry config cache-dir /ci-jobs-trigger \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ COPY ci_jobs_trigger/ /ci-jobs-trigger/ci_jobs_trigger/
 WORKDIR /ci-jobs-trigger
 
 # Set OCM_CONFIG to save ocm credentials for login
-RUN mkdir -p config/ocm \
-    && chmod 755 /ci-jobs-trigger/config/ocm
+RUN mkdir -p config/ocm && \
+    chgrp -R 0 /ci-jobs-trigger/config/ocm && \
+    chmod -R g=u /ci-jobs-trigger/config/ocm
 ENV OCM_CONFIG=/ci-jobs-trigger/config/ocm/ocm.json
 
 RUN python3 -m pip install pip --upgrade \


### PR DESCRIPTION
Getting permission denied error on GPC cluster.
`Zstream trigger: Error: Failed to execute 'Executing command: rosa login --env=https://api.stage.openshift.com --token=***** waiting for 300 seconds.': ERR: Failed to create OCM connection: error creating connection. Can't persist tokens to config: Failed to create directory /.config/ocm: mkdir /.config: permission denied`